### PR TITLE
Add grid ladder models and grid signal support

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,15 +1,47 @@
 name: Publish to PyPI and release on Github
 
 on:
-  push:
-    branches:
-      - '!main'
-      - '!master'
-      - '*'
+  pull_request:
   workflow_dispatch:
 
 jobs:
+  detect-version-bump:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+      version: ${{ steps.diff.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compare pyproject.toml version against PR base
+        id: diff
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          extract_version() {
+            awk -F'"' '/^version[[:space:]]*=/ { print $2; exit }' "$1"
+          }
+          base_version=""
+          if [ -n "${BASE_REF:-}" ]; then
+            git show "origin/${BASE_REF}:pyproject.toml" > base_pyproject.toml 2>/dev/null || true
+            if [ -s base_pyproject.toml ]; then
+              base_version=$(extract_version base_pyproject.toml)
+            fi
+          fi
+          head_version=$(extract_version pyproject.toml)
+          echo "base=$base_version head=$head_version"
+          if [ -n "$head_version" ] && [ "$base_version" != "$head_version" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$head_version" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-publish:
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/pybinbot/__init__.py
+++ b/pybinbot/__init__.py
@@ -60,6 +60,16 @@ from pybinbot.shared.handlers import (
 from pybinbot.models.bot_base import BotBase
 from pybinbot.models.deal import DealBase
 from pybinbot.models.order import OrderBase
+from pybinbot.models.grid_ladder import (
+    GridDeploymentRequest,
+    GridLadderCloseRequest,
+    GridLadderRecord,
+    GridLadderStatus,
+    GridLevelRecord,
+    GridLevelStatus,
+    GridOrderRecord,
+    GridOrderRole,
+)
 from pybinbot.models.signals import (
     HABollinguerSpread,
     SignalsConsumer,
@@ -115,6 +125,14 @@ __all__ = [
     "SymbolModel",
     "AssetIndexModel",
     "StandardResponse",
+    "GridDeploymentRequest",
+    "GridLadderRecord",
+    "GridLevelRecord",
+    "GridOrderRecord",
+    "GridLadderStatus",
+    "GridLevelStatus",
+    "GridOrderRole",
+    "GridLadderCloseRequest",
     "HABollinguerSpread",
     "SignalsConsumer",
     "KlineProduceModel",

--- a/pybinbot/apis/binbot/base.py
+++ b/pybinbot/apis/binbot/base.py
@@ -9,6 +9,7 @@ from pybinbot.apis.binance.base import BinanceApi
 from datetime import datetime, timezone
 from dateutil.parser import parse
 from pybinbot.models.symbol import AssetIndexModel, SymbolModel
+from pybinbot.models.grid_ladder import GridDeploymentRequest
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,8 @@ class BinbotApi:
         self.bb_timeseries_url = f"{bb_base_url}/charts/timeseries"
         self.bb_adr_series_url = f"{bb_base_url}/charts/adr-series"
         self.bb_signals_url = f"{bb_base_url}/signals"
+        self.bb_grid_ladders_url = f"{bb_base_url}/grid-ladders"
+        self.bb_active_grid_ladders_url = f"{bb_base_url}/grid-ladders/active"
 
         # Trade operations
         self.bb_buy_order_url = f"{bb_base_url}/order/buy"
@@ -259,6 +262,8 @@ class BinbotApi:
         context: dict | None = None,
         bot_params: dict | None = None,
         indicators: dict | None = None,
+        signal_kind: str = "bot",
+        grid_params: dict | None = None,
     ) -> dict | None:
         """
         Persist a strategy-emitted signal via POST /signals. Returns the
@@ -272,8 +277,10 @@ class BinbotApi:
             "direction": direction,
             "autotrade": autotrade,
             "current_regime": current_regime,
+            "signal_kind": signal_kind,
             "context": context or {},
             "bot_params": bot_params or {},
+            "grid_params": grid_params or {},
             "indicators": indicators or {},
         }
         try:
@@ -298,6 +305,8 @@ class BinbotApi:
         context: dict | None = None,
         bot_params: dict | None = None,
         indicators: dict | None = None,
+        signal_kind: str = "bot",
+        grid_params: dict | None = None,
     ) -> asyncio.Task:
         """
         Fire-and-forget version of create_signal. Returns immediately so the
@@ -314,11 +323,32 @@ class BinbotApi:
                 context=context,
                 bot_params=bot_params,
                 indicators=indicators,
+                signal_kind=signal_kind,
+                grid_params=grid_params,
             )
         )
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
         return task
+
+
+    async def create_grid_signal(
+        self, grid_params: GridDeploymentRequest, autotrade: bool
+    ) -> dict | None:
+        """Persist a grid deployment signal using the generic signal endpoint."""
+        return await self.create_signal(
+            algorithm_name=grid_params.algorithm_name,
+            symbol=grid_params.symbol,
+            generated_at=grid_params.generated_at,
+            direction="grid",
+            autotrade=autotrade,
+            current_regime=grid_params.current_regime,
+            context=grid_params.context,
+            bot_params={},
+            indicators=grid_params.indicators,
+            signal_kind="grid_deploy",
+            grid_params=grid_params.model_dump(mode="json"),
+        )
 
     def get_latest_btc_price(self):
         binance_api = BinanceApi()
@@ -389,6 +419,33 @@ class BinbotApi:
             json={"errors": errors},
         )
         return data
+
+
+    def create_grid_ladder(self, data: dict) -> dict:
+        response = self.request(url=self.bb_grid_ladders_url, method="POST", json=data)
+        return response
+
+    def get_grid_ladders(self) -> dict:
+        response = self.request(url=self.bb_grid_ladders_url)
+        return response
+
+    def get_active_grid_ladders(self) -> dict:
+        response = self.request(url=self.bb_active_grid_ladders_url)
+        return response
+
+    def get_grid_ladder(self, ladder_id: str) -> dict:
+        response = self.request(url=f"{self.bb_grid_ladders_url}/{ladder_id}")
+        return response
+
+    def close_grid_ladder(
+        self, ladder_id: str, data: dict | None = None
+    ) -> dict:
+        response = self.request(
+            url=f"{self.bb_grid_ladders_url}/{ladder_id}/close",
+            method="POST",
+            json=data or {},
+        )
+        return response
 
     def create_bot(self, data: dict) -> dict[Any, Any]:
         response = self.request(url=self.bb_bot_url, method="POST", json=data)

--- a/pybinbot/apis/binbot/base.py
+++ b/pybinbot/apis/binbot/base.py
@@ -331,7 +331,6 @@ class BinbotApi:
         task.add_done_callback(self._background_tasks.discard)
         return task
 
-
     async def create_grid_signal(
         self, grid_params: GridDeploymentRequest, autotrade: bool
     ) -> dict | None:
@@ -420,7 +419,6 @@ class BinbotApi:
         )
         return data
 
-
     def create_grid_ladder(self, data: dict) -> dict:
         response = self.request(url=self.bb_grid_ladders_url, method="POST", json=data)
         return response
@@ -437,9 +435,7 @@ class BinbotApi:
         response = self.request(url=f"{self.bb_grid_ladders_url}/{ladder_id}")
         return response
 
-    def close_grid_ladder(
-        self, ladder_id: str, data: dict | None = None
-    ) -> dict:
+    def close_grid_ladder(self, ladder_id: str, data: dict | None = None) -> dict:
         response = self.request(
             url=f"{self.bb_grid_ladders_url}/{ladder_id}/close",
             method="POST",

--- a/pybinbot/models/__init__.py
+++ b/pybinbot/models/__init__.py
@@ -1,0 +1,23 @@
+from pybinbot.models.grid_ladder import (
+    GridDeploymentRequest,
+    GridLadderCloseRequest,
+    GridLadderRecord,
+    GridLadderStatus,
+    GridLevelRecord,
+    GridLevelStatus,
+    GridOrderRecord,
+    GridOrderRole,
+    GridSignalKind,
+)
+
+__all__ = [
+    "GridDeploymentRequest",
+    "GridLadderCloseRequest",
+    "GridLadderRecord",
+    "GridLadderStatus",
+    "GridLevelRecord",
+    "GridLevelStatus",
+    "GridOrderRecord",
+    "GridOrderRole",
+    "GridSignalKind",
+]

--- a/pybinbot/models/grid_ladder.py
+++ b/pybinbot/models/grid_ladder.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from pybinbot.shared.enums import ExchangeId, MarketType, OrderType
+
+
+class GridSignalKind(str, Enum):
+    bot = "bot"
+    grid_deploy = "grid_deploy"
+    grid_close = "grid_close"
+
+
+class GridLadderStatus(str, Enum):
+    pending = "pending"
+    active = "active"
+    closing = "closing"
+    closed = "closed"
+    cancelled = "cancelled"
+    error = "error"
+
+
+class GridLevelStatus(str, Enum):
+    pending = "pending"
+    open = "open"
+    filled = "filled"
+    take_profit_open = "take_profit_open"
+    completed = "completed"
+    cancelled = "cancelled"
+    error = "error"
+
+
+class GridOrderRole(str, Enum):
+    entry = "entry"
+    take_profit = "take_profit"
+    stop_loss = "stop_loss"
+    close = "close"
+
+
+class GridDeploymentRequest(BaseModel):
+    symbol: str
+    fiat: str
+    exchange: ExchangeId | str
+    market_type: MarketType | str
+    algorithm_name: str
+    generated_at: datetime
+    range_low: float = Field(gt=0)
+    range_high: float = Field(gt=0)
+    level_count: int = Field(ge=3)
+    total_margin: float = Field(gt=0)
+    breakout_low: float = Field(gt=0)
+    breakout_high: float = Field(gt=0)
+    current_price: float = Field(gt=0)
+    current_regime: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+    indicators: dict[str, Any] = Field(default_factory=dict)
+    allocation_pct: float | None = Field(default=None, gt=0, le=100)
+    max_margin_per_ladder: float | None = Field(default=None, gt=0)
+    cash_reserve_pct: float | None = Field(default=None, ge=0, le=100)
+    entry_order_type: OrderType | str | None = None
+    reduce_only_take_profit: bool | None = None
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+    @model_validator(mode="after")
+    def validate_grid_boundaries(self) -> "GridDeploymentRequest":
+        if self.range_low >= self.range_high:
+            raise ValueError("range_low must be less than range_high")
+        if self.breakout_low >= self.range_low:
+            raise ValueError("breakout_low must be less than range_low")
+        if self.breakout_high <= self.range_high:
+            raise ValueError("breakout_high must be greater than range_high")
+        if not self.breakout_low <= self.current_price <= self.breakout_high:
+            raise ValueError("current_price must be inside or near the grid range")
+        return self
+
+
+class GridLevelRecord(BaseModel):
+    id: str | None = None
+    ladder_id: str | None = None
+    level_index: int = Field(ge=0)
+    price: float = Field(gt=0)
+    margin: float = Field(ge=0)
+    quantity: float | None = Field(default=None, ge=0)
+    status: GridLevelStatus = GridLevelStatus.pending
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+
+class GridOrderRecord(BaseModel):
+    id: str | None = None
+    ladder_id: str | None = None
+    level_id: str | None = None
+    exchange_order_id: str | None = None
+    role: GridOrderRole
+    status: str | None = None
+    side: str | None = None
+    price: float | None = Field(default=None, gt=0)
+    quantity: float | None = Field(default=None, ge=0)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+
+class GridLadderRecord(BaseModel):
+    id: str | None = None
+    symbol: str
+    fiat: str
+    exchange: ExchangeId | str
+    market_type: MarketType | str
+    algorithm_name: str
+    status: GridLadderStatus = GridLadderStatus.pending
+    generated_at: datetime
+    range_low: float
+    range_high: float
+    level_count: int
+    total_margin: float
+    breakout_low: float
+    breakout_high: float
+    current_price: float
+    current_regime: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+    indicators: dict[str, Any] = Field(default_factory=dict)
+    levels: list[GridLevelRecord] = Field(default_factory=list)
+    orders: list[GridOrderRecord] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+
+class GridLadderCloseRequest(BaseModel):
+    reason: str | None = None
+    cancel_open_orders: bool = True
+    close_positions: bool = True
+    reduce_only: bool = True
+    context: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class GridLadderResponse(BaseModel):
+    data: GridLadderRecord | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class GridLadderListResponse(BaseModel):
+    data: list[GridLadderRecord] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")

--- a/pybinbot/models/grid_ladder.py
+++ b/pybinbot/models/grid_ladder.py
@@ -78,34 +78,63 @@ class GridDeploymentRequest(BaseModel):
 
 
 class GridLevelRecord(BaseModel):
+    """
+    Persisted grid level as returned by binbot's grid-ladder endpoints.
+    Field names mirror `GridLevelTable` so clients can use this model
+    to deserialize `GET /grid-ladders/{id}.detail.levels[*]`.
+    """
+
     id: str | None = None
     ladder_id: str | None = None
     level_index: int = Field(ge=0)
     price: float = Field(gt=0)
-    margin: float = Field(ge=0)
-    quantity: float | None = Field(default=None, ge=0)
-    status: GridLevelStatus = GridLevelStatus.pending
+    side: str
+    contracts: int = Field(ge=0)
+    margin_required: float = Field(ge=0)
+    status: str
+    entry_order_id: str | None = None
+    take_profit_order_id: str | None = None
+    filled_entry_price: float | None = None
+    filled_entry_qty: float = 0
+    take_profit_price: float | None = None
+    realized_pnl: float = 0
+    created_at: float | None = None
+    updated_at: float | None = None
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 
 
 class GridOrderRecord(BaseModel):
+    """
+    Persisted grid order as returned by binbot's grid-ladder endpoints.
+    Field names mirror `GridOrderTable`.
+    """
+
     id: str | None = None
     ladder_id: str | None = None
     level_id: str | None = None
     exchange_order_id: str | None = None
-    role: GridOrderRole
+    client_oid: str | None = None
+    order_role: str
     status: str | None = None
     side: str | None = None
     price: float | None = Field(default=None, gt=0)
-    quantity: float | None = Field(default=None, ge=0)
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+    contracts: int = 0
+    filled_qty: float = 0
+    filled_price: float | None = None
+    created_at: float | None = None
+    updated_at: float | None = None
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 
 
 class GridLadderRecord(BaseModel):
+    """
+    Persisted grid ladder as returned by binbot's grid-ladder endpoints.
+    Field names mirror `GridLadderTable` (timestamps are floats, IDs are
+    UUID strings) so clients can deserialize `detail` from the response.
+    """
+
     id: str | None = None
     symbol: str
     fiat: str
@@ -113,21 +142,23 @@ class GridLadderRecord(BaseModel):
     market_type: MarketType | str
     algorithm_name: str
     status: GridLadderStatus = GridLadderStatus.pending
-    generated_at: datetime
     range_low: float
     range_high: float
+    grid_step: float
     level_count: int
     total_margin: float
+    reserved_margin: float = 0
+    used_margin: float = 0
+    realized_pnl: float = 0
+    unrealized_pnl: float = 0
     breakout_low: float
     breakout_high: float
-    current_price: float
-    current_regime: str | None = None
+    created_at: float | None = None
+    updated_at: float | None = None
+    closed_at: float | None = None
     context: dict[str, Any] = Field(default_factory=dict)
-    indicators: dict[str, Any] = Field(default_factory=dict)
     levels: list[GridLevelRecord] = Field(default_factory=list)
     orders: list[GridOrderRecord] = Field(default_factory=list)
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 
@@ -143,12 +174,12 @@ class GridLadderCloseRequest(BaseModel):
 
 
 class GridLadderResponse(BaseModel):
-    data: GridLadderRecord | None = None
+    detail: GridLadderRecord | None = None
 
     model_config = ConfigDict(extra="allow")
 
 
 class GridLadderListResponse(BaseModel):
-    data: list[GridLadderRecord] = Field(default_factory=list)
+    detail: list[GridLadderRecord] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="allow")

--- a/pybinbot/models/signals.py
+++ b/pybinbot/models/signals.py
@@ -50,10 +50,10 @@ class SignalsConsumer(BaseModel):
 
     @model_validator(mode="after")
     def validate_signal_payload(self) -> "SignalsConsumer":
-        if self.signal_kind == "bot" and self.bot_params is None:
-            raise ValueError("bot_params is required when signal_kind is bot")
         if self.signal_kind == "grid_deploy" and self.grid_params is None:
             raise ValueError("grid_params is required when signal_kind is grid_deploy")
+        if self.signal_kind == "grid_close" and self.grid_params is None:
+            raise ValueError("grid_params is required when signal_kind is grid_close")
         return self
 
     @field_validator("spread", "current_price")

--- a/pybinbot/models/signals.py
+++ b/pybinbot/models/signals.py
@@ -1,9 +1,12 @@
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pybinbot.shared.enums import MarketType
 from pandera.typing import Series
 from pandera.pandas import DataFrameModel
 from pybinbot.models.bot_base import BotBase
+from pybinbot.models.grid_ladder import GridDeploymentRequest
 
 
 class HABollinguerSpread(BaseModel):
@@ -30,14 +33,28 @@ class SignalsConsumer(BaseModel):
     current_price: float = Field(default=0)
     bb_spreads: HABollinguerSpread | None = Field(default=None)
     autotrade: bool = Field(default=True, description="If it is in testing mode, False")
+    signal_kind: Literal["bot", "grid_deploy", "grid_close"] = Field(
+        default="bot", description="Signal envelope kind"
+    )
     bot_params: BotBase | None = Field(
         default=None, description="Parameters for bot creation"
+    )
+    grid_params: GridDeploymentRequest | None = Field(
+        default=None, description="Parameters for grid ladder deployment"
     )
 
     model_config = ConfigDict(
         extra="allow",
         use_enum_values=True,
     )
+
+    @model_validator(mode="after")
+    def validate_signal_payload(self) -> "SignalsConsumer":
+        if self.signal_kind == "bot" and self.bot_params is None:
+            raise ValueError("bot_params is required when signal_kind is bot")
+        if self.signal_kind == "grid_deploy" and self.grid_params is None:
+            raise ValueError("grid_params is required when signal_kind is grid_deploy")
+        return self
 
     @field_validator("spread", "current_price")
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.9.2"
+version = "1.9.3"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.9.3"
+version = "1.9.5"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.9.0"
+version = "1.9.1"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.9.1"
+version = "1.9.2"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.8.22"
+version = "1.9.0"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/tests/test_binbot_api.py
+++ b/tests/test_binbot_api.py
@@ -71,6 +71,13 @@ def load_binbot_api_class():
     symbol_stub.AssetIndexModel = AssetIndexModel
     symbol_stub.SymbolModel = SymbolModel
 
+    grid_stub = types.ModuleType("pybinbot.models.grid_ladder")
+
+    class GridDeploymentRequest(BaseModel):
+        pass
+
+    grid_stub.GridDeploymentRequest = GridDeploymentRequest
+
     handlers_stub = types.ModuleType("pybinbot.shared.handlers")
     handlers_stub.handle_binbot_errors = lambda response: response
 
@@ -96,6 +103,7 @@ def load_binbot_api_class():
             "pybinbot": pybinbot_stub,
             "pybinbot.models": models_stub,
             "pybinbot.models.symbol": symbol_stub,
+            "pybinbot.models.grid_ladder": grid_stub,
             "pybinbot.shared.handlers": handlers_stub,
             "pybinbot.apis.binance.base": binance_stub,
         },

--- a/tests/test_grid_ladder.py
+++ b/tests/test_grid_ladder.py
@@ -1,0 +1,169 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from pybinbot.apis.binbot.base import BinbotApi
+from pybinbot.models.bot_base import BotBase
+from pybinbot.models.grid_ladder import GridDeploymentRequest
+from pybinbot.models.signals import SignalsConsumer
+
+
+def valid_grid_payload() -> dict:
+    return {
+        "symbol": "BTCUSDC",
+        "fiat": "USDC",
+        "exchange": "kucoin",
+        "market_type": "SPOT",
+        "algorithm_name": "grid-test",
+        "generated_at": datetime(2026, 5, 18, tzinfo=timezone.utc),
+        "range_low": 90.0,
+        "range_high": 110.0,
+        "level_count": 5,
+        "total_margin": 100.0,
+        "breakout_low": 80.0,
+        "breakout_high": 120.0,
+        "current_price": 100.0,
+        "current_regime": "range",
+        "context": {"timeframe": "15m"},
+        "indicators": {"rsi": 50},
+    }
+
+
+def test_grid_deployment_request_rejects_invalid_range() -> None:
+    payload = valid_grid_payload()
+    payload["range_low"] = 110.0
+    payload["range_high"] = 90.0
+
+    with pytest.raises(ValidationError, match="range_low must be less than range_high"):
+        GridDeploymentRequest(**payload)
+
+
+def test_grid_deployment_request_rejects_breakout_inside_range() -> None:
+    payload = valid_grid_payload()
+    payload["breakout_low"] = 95.0
+
+    with pytest.raises(ValidationError, match="breakout_low must be less than range_low"):
+        GridDeploymentRequest(**payload)
+
+
+def test_grid_deployment_request_accepts_valid_five_level_ladder() -> None:
+    deployment = GridDeploymentRequest(**valid_grid_payload())
+
+    assert deployment.symbol == "BTCUSDC"
+    assert deployment.level_count == 5
+    assert deployment.total_margin == 100.0
+
+
+def test_signals_consumer_accepts_normal_bot_signal_unchanged() -> None:
+    bot = BotBase(pair="BTCUSDC", fiat="USDC")
+
+    signal = SignalsConsumer(direction="buy", bot_params=bot)
+
+    assert signal.signal_kind == "bot"
+    assert signal.bot_params is not None
+    assert signal.bot_params.pair == "BTCUSDC"
+
+
+def test_signals_consumer_accepts_grid_deploy_signal_with_grid_params() -> None:
+    grid_params = GridDeploymentRequest(**valid_grid_payload())
+
+    signal = SignalsConsumer(
+        signal_kind="grid_deploy",
+        direction="grid",
+        grid_params=grid_params,
+    )
+
+    assert signal.signal_kind == "grid_deploy"
+    assert signal.grid_params is not None
+    assert signal.grid_params.symbol == "BTCUSDC"
+
+
+@pytest.mark.asyncio
+async def test_create_signal_includes_signal_kind_and_grid_params_in_payload() -> None:
+    api = object.__new__(BinbotApi)
+    api.bb_signals_url = "https://example.com/signals"
+    captured: dict = {}
+
+    async def fake_fetch(**kwargs):
+        captured.update(kwargs)
+        return {"data": {"id": "signal-1"}}
+
+    api.fetch = fake_fetch
+
+    result = await api.create_signal(
+        algorithm_name="grid-test",
+        symbol="BTCUSDC",
+        generated_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        direction="grid",
+        autotrade=True,
+        current_regime="range",
+        signal_kind="grid_deploy",
+        grid_params={"symbol": "BTCUSDC"},
+    )
+
+    assert result == {"id": "signal-1"}
+    assert captured["url"] == "https://example.com/signals"
+    assert captured["method"] == "POST"
+    assert captured["json"]["signal_kind"] == "grid_deploy"
+    assert captured["json"]["grid_params"] == {"symbol": "BTCUSDC"}
+    assert captured["json"]["bot_params"] == {}
+
+
+@pytest.mark.asyncio
+async def test_create_grid_signal_serializes_deployment_request_correctly() -> None:
+    api = object.__new__(BinbotApi)
+    deployment = GridDeploymentRequest(**valid_grid_payload())
+    captured: dict = {}
+
+    async def fake_create_signal(**kwargs):
+        captured.update(kwargs)
+        return {"id": "signal-1"}
+
+    api.create_signal = fake_create_signal
+
+    result = await api.create_grid_signal(deployment, autotrade=True)
+
+    assert result == {"id": "signal-1"}
+    assert captured["algorithm_name"] == "grid-test"
+    assert captured["symbol"] == "BTCUSDC"
+    assert captured["direction"] == "grid"
+    assert captured["autotrade"] is True
+    assert captured["signal_kind"] == "grid_deploy"
+    assert captured["bot_params"] == {}
+    assert captured["grid_params"] == deployment.model_dump(mode="json")
+
+
+def test_grid_ladder_client_methods_use_explicit_urls() -> None:
+    api = object.__new__(BinbotApi)
+    api.bb_grid_ladders_url = "https://example.com/grid-ladders"
+    api.bb_active_grid_ladders_url = "https://example.com/grid-ladders/active"
+    calls: list[dict] = []
+
+    def fake_request(**kwargs):
+        calls.append(kwargs)
+        return {"ok": True}
+
+    api.request = fake_request
+
+    assert api.create_grid_ladder({"symbol": "BTCUSDC"}) == {"ok": True}
+    assert api.get_grid_ladders() == {"ok": True}
+    assert api.get_active_grid_ladders() == {"ok": True}
+    assert api.get_grid_ladder("ladder-1") == {"ok": True}
+    assert api.close_grid_ladder("ladder-1", {"reason": "test"}) == {"ok": True}
+
+    assert calls == [
+        {
+            "url": "https://example.com/grid-ladders",
+            "method": "POST",
+            "json": {"symbol": "BTCUSDC"},
+        },
+        {"url": "https://example.com/grid-ladders"},
+        {"url": "https://example.com/grid-ladders/active"},
+        {"url": "https://example.com/grid-ladders/ladder-1"},
+        {
+            "url": "https://example.com/grid-ladders/ladder-1/close",
+            "method": "POST",
+            "json": {"reason": "test"},
+        },
+    ]

--- a/tests/test_grid_ladder.py
+++ b/tests/test_grid_ladder.py
@@ -43,7 +43,9 @@ def test_grid_deployment_request_rejects_breakout_inside_range() -> None:
     payload = valid_grid_payload()
     payload["breakout_low"] = 95.0
 
-    with pytest.raises(ValidationError, match="breakout_low must be less than range_low"):
+    with pytest.raises(
+        ValidationError, match="breakout_low must be less than range_low"
+    ):
         GridDeploymentRequest(**payload)
 
 
@@ -80,7 +82,9 @@ def test_signals_consumer_accepts_grid_deploy_signal_with_grid_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_signal_includes_signal_kind_and_grid_params_in_payload() -> None:
+async def test_create_signal_includes_signal_kind_and_grid_params_in_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api = object.__new__(BinbotApi)
     api.bb_signals_url = "https://example.com/signals"
     captured: dict = {}
@@ -89,7 +93,7 @@ async def test_create_signal_includes_signal_kind_and_grid_params_in_payload() -
         captured.update(kwargs)
         return {"data": {"id": "signal-1"}}
 
-    api.fetch = fake_fetch
+    monkeypatch.setattr(api, "fetch", fake_fetch)
 
     result = await api.create_signal(
         algorithm_name="grid-test",
@@ -111,7 +115,9 @@ async def test_create_signal_includes_signal_kind_and_grid_params_in_payload() -
 
 
 @pytest.mark.asyncio
-async def test_create_grid_signal_serializes_deployment_request_correctly() -> None:
+async def test_create_grid_signal_serializes_deployment_request_correctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api = object.__new__(BinbotApi)
     deployment = GridDeploymentRequest(**valid_grid_payload())
     captured: dict = {}
@@ -120,7 +126,7 @@ async def test_create_grid_signal_serializes_deployment_request_correctly() -> N
         captured.update(kwargs)
         return {"id": "signal-1"}
 
-    api.create_signal = fake_create_signal
+    monkeypatch.setattr(api, "create_signal", fake_create_signal)
 
     result = await api.create_grid_signal(deployment, autotrade=True)
 
@@ -134,7 +140,9 @@ async def test_create_grid_signal_serializes_deployment_request_correctly() -> N
     assert captured["grid_params"] == deployment.model_dump(mode="json")
 
 
-def test_grid_ladder_client_methods_use_explicit_urls() -> None:
+def test_grid_ladder_client_methods_use_explicit_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api = object.__new__(BinbotApi)
     api.bb_grid_ladders_url = "https://example.com/grid-ladders"
     api.bb_active_grid_ladders_url = "https://example.com/grid-ladders/active"
@@ -144,7 +152,7 @@ def test_grid_ladder_client_methods_use_explicit_urls() -> None:
         calls.append(kwargs)
         return {"ok": True}
 
-    api.request = fake_request
+    monkeypatch.setattr(api, "request", fake_request)
 
     assert api.create_grid_ladder({"symbol": "BTCUSDC"}) == {"ok": True}
     assert api.get_grid_ladders() == {"ok": True}

--- a/uv.lock
+++ b/uv.lock
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.9.2"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.8.22"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.8.21"
+version = "1.8.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Motivation

- Introduce a typed, self-contained representation for grid ladder deployments to keep grid-specific deployment data separate from `BotBase` and to make grid-related communication explicit and validated.
- Extend the signal envelope and persistence so grid deployment decisions can be recorded and audited via the existing `/signals` endpoint without changing existing bot signal semantics.

### Description

- Added `pybinbot/models/grid_ladder.py` containing `GridSignalKind`, `GridLadderStatus`, `GridLevelStatus`, `GridOrderRole`, `GridDeploymentRequest`, `GridLevelRecord`, `GridOrderRecord`, `GridLadderRecord`, `GridLadderCloseRequest`, `GridLadderResponse`, and `GridLadderListResponse`, with validation enforcing `range_low < range_high`, `breakout_low < range_low`, `breakout_high > range_high`, `level_count >= 3`, positive margins/prices, and ensuring `current_price` lies inside the breakout envelope; model config keeps `extra='allow'` and `use_enum_values`.
- Extended `SignalsConsumer` (`pybinbot/models/signals.py`) to include `signal_kind: Literal["bot","grid_deploy","grid_close"]` and `grid_params: GridDeploymentRequest | None` while keeping `bot_params` separate, and added a consumer-side `@model_validator` to require the appropriate params for the declared `signal_kind`.
- Added Binbot API client support in `pybinbot/apis/binbot/base.py`: new URLs `bb_grid_ladders_url` and `bb_active_grid_ladders_url`, signal persistence payload expanded with `signal_kind` and `grid_params`, `dispatch_create_signal` forwarding, a convenience `create_grid_signal(grid_params: GridDeploymentRequest, autotrade: bool)` that serializes a `GridDeploymentRequest`, and explicit client methods `create_grid_ladder`, `get_grid_ladders`, `get_active_grid_ladders`, `get_grid_ladder`, and `close_grid_ladder`.
- Exported the new models from `pybinbot/models/__init__.py` and added them to the package public API in `pybinbot/__init__.py` so callers can `from pybinbot import GridDeploymentRequest, SignalsConsumer`.
- Added contract tests in `tests/test_grid_ladder.py` and updated `tests/test_binbot_api.py` to cover validation rules, `SignalsConsumer` usage for `bot` and `grid_deploy`, `create_signal` payload content, `create_grid_signal` serialization, and the client grid-ladder URL methods.

### Testing

- Ran linting with `uv run --frozen ruff check .` and the check passed.
- Ran the full test suite with `uv run --frozen pytest -q`, which completed successfully with tests passing (127 passed, 40 warnings reported by dependencies); newly added tests in `tests/test_grid_ladder.py` passed.
- Added unit-style contract tests that validate the new model rules and client behavior and verified they succeed in CI-local runs described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b98d6b76c8320aed129de2653022f)