### PR TITLE
Add multiplier field to SymbolModel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,5 @@ _bump-version:
 tag: ## Tag the current version from pyproject.toml (no commit or push)
 	@VERSION=$$(grep '^version\s*=\s*"[0-9]\+\.[0-9]\+\.[0-9]\+"' pyproject.toml | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/') ; \
 		echo "Tagging v$$VERSION" ; \
-		git tag "v$$VERSION"
-		git push origin --tags
+		git tag "v$$VERSION" ; \
+		git push origin "v$$VERSION"

--- a/pybinbot/apis/binbot/base.py
+++ b/pybinbot/apis/binbot/base.py
@@ -244,6 +244,7 @@ class BinbotApi:
         price_precision: int | None = None,
         qty_precision: int | None = None,
         min_notional: float | None = None,
+        multiplier: float | None = None,
     ) -> SymbolModel:
         """
         PUT /symbol — update a symbol row.
@@ -267,6 +268,7 @@ class BinbotApi:
             price_precision=price_precision,
             qty_precision=qty_precision,
             min_notional=min_notional,
+            multiplier=multiplier,
         )
         payload["symbol"] = payload.pop("id")
         response = self.request(

--- a/pybinbot/models/symbol.py
+++ b/pybinbot/models/symbol.py
@@ -48,6 +48,12 @@ class SymbolModel(BaseModel):
     )
     qty_precision: int = Field(default=0)
     min_notional: float = Field(default=0, description="Minimum price x qty value")
+    multiplier: float = Field(
+        default=1.0,
+        description="Futures contract multiplier: quantity of the underlying "
+        "asset represented by one contract (e.g. KuCoin XBTUSDTM=0.001). "
+        "Not meaningful for spot/margin, where it stays 1.0.",
+    )
 
     _update_model: ClassVar[type[BaseModel] | None] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pybinbot"
-version = "1.11.5"
+version = "1.11.8"
 description = "Utility functions for the binbot project."
 authors = [
     { name="Carlos Wu", email="carkodw@gmail.com" }

--- a/tests/test_binbot_api.py
+++ b/tests/test_binbot_api.py
@@ -30,6 +30,7 @@ class _SymbolModel(BaseModel):
     price_precision: int = 0
     qty_precision: int = 0
     min_notional: float = 0
+    multiplier: float = 1.0
 
     @classmethod
     def to_update_payload(cls, **fields: object) -> dict:

--- a/tests/test_symbol_model.py
+++ b/tests/test_symbol_model.py
@@ -23,3 +23,9 @@ def test_symbol_update_payload_validates_model_constraints() -> None:
 def test_symbol_update_payload_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="Extra inputs are not permitted"):
         SymbolModel.to_update_payload(symbol="BTCUSDTM")
+
+
+def test_symbol_multiplier_defaults_to_one() -> None:
+    symbol = SymbolModel(id="BTCUSDT", exchange_id="binance")
+
+    assert symbol.multiplier == 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pybinbot"
-version = "1.11.5"
+version = "1.11.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Futures contract multiplier (quantity of underlying asset per contract, e.g. KuCoin XBTUSDTM=0.001) — mirrors binbot's new SymbolExchangeTable.multiplier column so it can round-trip through the API once binbot's dependency on this package is bumped.